### PR TITLE
fix(blog): resolve animation conflict on blog cards - separate opacit…

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,2 @@
-export { default as useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
-export { default as useWindowSize } from './use-window-size';
+export { default as useIsomorphicLayoutEffect } from "./use-isomorphic-layout-effect";
+export { default as useWindowSize } from "./use-window-size";

--- a/src/react-pages/BlogApp.tsx
+++ b/src/react-pages/BlogApp.tsx
@@ -123,8 +123,10 @@ const BlogApp = ({ posts }: BlogAppProps): JSX.Element => {
           <Container>
             <GsapStaggerInView
               className="blog-grid"
-              stagger={0.12}
-              duration={0.9}
+              from={{ opacity: 0 }}
+              to={{ opacity: 1 }}
+              stagger={0.15}
+              duration={0.6}
             >
               {filteredPosts.map((post) => {
                 const linkSlug = normalizeSlug(post.contentSlug ?? post.slug);
@@ -133,40 +135,44 @@ const BlogApp = ({ posts }: BlogAppProps): JSX.Element => {
                 const cardImage = getPostImage(post.featuredImage);
 
                 return (
-                  <article className="blog-card" key={post.contentId}>
-                    <GsapScaleBounce as="div" delay={0.05} repeat={0}>
-                      <p className="blog-card-date margin-0">
-                        {formatDate(post.date, currentLanguage)}
-                      </p>
-                      <h2 className="h3 margin-t-b-1">{title}</h2>
+                  <GsapScaleBounce
+                    as="article"
+                    className="blog-card"
+                    key={post.contentId}
+                    delay={0.5}
+                    repeat={0}
+                  >
+                    <p className="blog-card-date margin-0">
+                      {formatDate(post.date, currentLanguage)}
+                    </p>
+                    <h2 className="h3 margin-t-b-1">{title}</h2>
 
-                      <img
-                        src={cardImage}
-                        alt={title}
-                        className="card-img"
-                        loading="lazy"
-                      />
+                    <img
+                      src={cardImage}
+                      alt={title}
+                      className="card-img"
+                      loading="lazy"
+                    />
 
-                      <p className="blog-card-description">{description}</p>
+                    <p className="blog-card-description">{description}</p>
 
-                      {!!post.contentTags?.length && (
-                        <div className="blog-card-tags">
-                          {post.contentTags.map((tag) => (
-                            <span
-                              key={`${post.contentId}-${tag}`}
-                              className="badge blog-tag"
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      )}
+                    {!!post.contentTags?.length && (
+                      <div className="blog-card-tags">
+                        {post.contentTags.map((tag) => (
+                          <span
+                            key={`${post.contentId}-${tag}`}
+                            className="badge blog-tag"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
 
-                      <a className="blog-read-link" href={`/blog/${linkSlug}`}>
-                        {t("blogPage.list.readArticle")}
-                      </a>
-                    </GsapScaleBounce>
-                  </article>
+                    <a className="blog-read-link" href={`/blog/${linkSlug}`}>
+                      {t("blogPage.list.readArticle")}
+                    </a>
+                  </GsapScaleBounce>
                 );
               })}
             </GsapStaggerInView>


### PR DESCRIPTION
This pull request updates the animation and markup structure for the blog post cards in the `BlogApp` component, as well as makes a minor formatting change in the hooks index file. The main changes improve the animation effects for blog post entries, enhance semantic HTML, and clean up code formatting.

**Animation and UI improvements:**

* Updated the `GsapStaggerInView` animation for the blog grid to use `from` and `to` opacity values, increased the stagger to `0.15`, and reduced the duration to `0.6` for a smoother fade-in effect.
* Changed the `GsapScaleBounce` wrapper to use `as="article"` instead of wrapping an `article` element, moved the `blog-card` class and `key` prop to this component, increased the delay to `0.5`, and removed the redundant outer `article` tag for improved semantics and cleaner structure. [[1]](diffhunk://#diff-41ffc1c417138347fb7c4630d9f34852b5c7bb0219ab35731d958f7ae8f55b8dL136-R144) [[2]](diffhunk://#diff-41ffc1c417138347fb7c4630d9f34852b5c7bb0219ab35731d958f7ae8f55b8dL169)

**Code formatting:**

* Standardized import style in `src/hooks/index.ts` by switching to double quotes for consistency.…y stagger from scale bounce animation to avoid conflicting y property